### PR TITLE
Add UniversityQuery Controller and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
@@ -34,10 +34,10 @@ public class UniversityController {
     @Operation(summary="Get list of universities that match a given name", description ="Uses API documented here: http://universities.hipolabs.com/search")
     @GetMapping("/get")
     public ResponseEntity<String> getUniversities(
-        @Parameter(name="university", description="name to search", example="Harvard") @RequestParam String name
+        @Parameter(name="university", description="name to search", example="Harvard") @RequestParam String university
     ) throws JsonProcessingException {
-        log.info("getUniversity: name={}", name);
-        String result = universityQueryService.getJSON(name);
+        log.info("getUniversity: name={}", university);
+        String result = universityQueryService.getJSON(university);
         return ResponseEntity.ok().body(result);
     }
 

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
@@ -2,8 +2,43 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="University info from universities.hipolabs.com")
+@Slf4j
 @RestController
+@RequestMapping("/api/university")
 public class UniversityController {
-    
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    UniversityQueryService universityQueryService;
+
+    @Operation(summary="Get list of universities that match a given name", description ="Uses API documented here: http://universities.hipolabs.com/search")
+    @GetMapping("/get")
+    public ResponseEntity<String> getUniversities(
+        @Parameter(name="university", description="name to search", example="Harvard") @RequestParam String name
+    ) throws JsonProcessingException {
+        log.info("getUniversity: name={}", name);
+        String result = universityQueryService.getJSON(name);
+        return ResponseEntity.ok().body(result);
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
@@ -22,6 +22,7 @@ import org.springframework.web.client.HttpClientErrorException;
 @Service
 public class UniversityQueryService {
 
+    ObjectMapper mapper = new ObjectMapper();
 
     private final RestTemplate restTemplate;
 
@@ -33,8 +34,16 @@ public class UniversityQueryService {
 
     public String getJSON(String name) throws HttpClientErrorException {
         log.info("name={}", name);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
         Map<String, String> uriVariables = Map.of("name", name);
 
-        return "";
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
-
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -9,7 +10,11 @@ import org.springframework.web.client.RestTemplate;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
-
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -24,9 +29,12 @@ public class UniversityQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "http://universities.hipolabs.com/search?name={name}";
 
     public String getJSON(String name) throws HttpClientErrorException {
-       return "";
+        log.info("name={}", name);
+        Map<String, String> uriVariables = Map.of("name", name);
+
+        return "";
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
@@ -1,0 +1,49 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(value = UniversityController.class)
+public class UniversityControllerTests {
+    private ObjectMapper mapper = new ObjectMapper();
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    UniversityQueryService mockUniversityQueryService;
+    
+    @Test
+    public void test_getUniversities() throws Exception {
+
+        String fakeJsonResult="{ \"fake\" : \"result\" }";
+        String name = "Harvard";
+        when(mockUniversityQueryService.getJSON(eq(name))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/university/get?name=%s", name);
+
+        MvcResult response = mockMvc
+            .perform( get(url).contentType("application/json"))
+            .andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
@@ -36,7 +36,7 @@ public class UniversityControllerTests {
         String name = "Harvard";
         when(mockUniversityQueryService.getJSON(eq(name))).thenReturn(fakeJsonResult);
 
-        String url = String.format("/api/university/get?name=%s", name);
+        String url = String.format("/api/university/get?university=%s", name);
 
         MvcResult response = mockMvc
             .perform( get(url).contentType("application/json"))

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
@@ -12,20 +12,20 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 
-@RestClientTest(CountryCodeQueryService.class)
-public class CountryCodeQueryServiceTests {
+@RestClientTest(UniversityQueryService.class)
+public class UniversityQueryServiceTests {
 
     @Autowired
     private MockRestServiceServer mockRestServiceServer;
 
     @Autowired
-    private CountryCodeQueryService countryCodeQueryService;
+    private UniversityQueryService UniversityQueryService;
 
     @Test
     public void test_getJSON() {
 
-        String country = "UnitedStates";
-        String expectedURL = CountryCodeQueryService.ENDPOINT.replace("{country}", country);
+        String name = "Harvard";
+        String expectedURL = UniversityQueryService.ENDPOINT.replace("{name}", name);
 
         String fakeJsonResult = "{ \"fake\" : \"result\" }";
 
@@ -34,7 +34,7 @@ public class CountryCodeQueryServiceTests {
                 .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
                 .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
 
-        String actualResult = countryCodeQueryService.getJSON(country);
+        String actualResult = UniversityQueryService.getJSON(name);
         assertEquals(fakeJsonResult, actualResult);
     }
 }


### PR DESCRIPTION
In this PR, we add an endpoint `/api/university/get` that can be used to get information about the location of a particular zipcode.

Closes #24 

Dev deployment: http://team01-luxiangzh-dev.dokku-12.cs.ucsb.edu/swagger-ui/index.html